### PR TITLE
content.js : Added a null check for frame

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -217,7 +217,7 @@ function KindleBook() {
   function getTexts() {
     var texts = [];
     contentFrames.filter(function(frame) {
-      return frame.style.visibility != "hidden";
+      return frame != null && frame.style.visibility != "hidden";
     })
     .forEach(function(frame) {
       var frameHeight = $(frame).height();


### PR DESCRIPTION
Was throwing an error when frame is null in getTexts(). Added a null check.